### PR TITLE
OSOE-529: Include dynamic base theme when GetFeatures is called

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,8 @@
 * text=auto
 
+# Enforce Windows newlines for C# files to avoid false positives with IDE0055 warning.
+# See https://github.com/Lombiq/Open-Source-Orchard-Core-Extensions/issues/106 for more information.
+*.cs text eol=crlf
+
 # Keep LF line endings in pnpm-lock.yaml files to prevent Git from reporting this file as changed after pnpm touches it.
 pnpm-lock.yaml text eol=lf

--- a/Lombiq.Hosting.MediaTheme.Bridge/Services/ExtensionManagerDecorator.cs
+++ b/Lombiq.Hosting.MediaTheme.Bridge/Services/ExtensionManagerDecorator.cs
@@ -54,8 +54,17 @@ public class ExtensionManagerDecorator : IExtensionManager
     public IEnumerable<IFeatureInfo> GetFeatures() =>
         _decorated.GetFeatures();
 
-    public IEnumerable<IFeatureInfo> GetFeatures(string[] featureIdsToLoad) =>
-        _decorated.GetFeatures(featureIdsToLoad);
+    public IEnumerable<IFeatureInfo> GetFeatures(string[] featureIdsToLoad)
+    {
+        if (featureIdsToLoad.Contains(FeatureNames.MediaTheme))
+        {
+            // As stated above, it'll be retrieved from cache so it's not an issue.
+            var baseThemeId = _mediaThemeStateStore.GetMediaThemeStateAsync().GetAwaiter().GetResult()?.BaseThemeId;
+            if (!string.IsNullOrEmpty(baseThemeId)) featureIdsToLoad = featureIdsToLoad.Append(baseThemeId).ToArray();
+        }
+
+        return _decorated.GetFeatures(featureIdsToLoad);
+    }
 
     public IEnumerable<IFeatureInfo> GetDependentFeatures(string featureId) =>
         _decorated.GetDependentFeatures(featureId);

--- a/Lombiq.Hosting.MediaTheme.Bridge/Services/ExtensionManagerDecorator.cs
+++ b/Lombiq.Hosting.MediaTheme.Bridge/Services/ExtensionManagerDecorator.cs
@@ -26,8 +26,7 @@ public class ExtensionManagerDecorator : IExtensionManager
 
         if (featureId != FeatureNames.MediaTheme) return dependencies;
 
-        // It'll be retrieved from cache so it's not an issue.
-        var baseThemeId = _mediaThemeStateStore.GetMediaThemeStateAsync().GetAwaiter().GetResult()?.BaseThemeId;
+        var baseThemeId = GetBaseThemeId();
         if (string.IsNullOrEmpty(baseThemeId)) return dependencies;
 
         var allFeatures = GetFeatures().ToArray();
@@ -58,8 +57,7 @@ public class ExtensionManagerDecorator : IExtensionManager
     {
         if (featureIdsToLoad.Contains(FeatureNames.MediaTheme))
         {
-            // As stated above, it'll be retrieved from cache so it's not an issue.
-            var baseThemeId = _mediaThemeStateStore.GetMediaThemeStateAsync().GetAwaiter().GetResult()?.BaseThemeId;
+            var baseThemeId = GetBaseThemeId();
             if (!string.IsNullOrEmpty(baseThemeId)) featureIdsToLoad = featureIdsToLoad.Append(baseThemeId).ToArray();
         }
 
@@ -74,4 +72,8 @@ public class ExtensionManagerDecorator : IExtensionManager
 
     public Task<IEnumerable<FeatureEntry>> LoadFeaturesAsync(string[] featureIdsToLoad) =>
         _decorated.LoadFeaturesAsync(featureIdsToLoad);
+
+    private string GetBaseThemeId() =>
+        // It'll be retrieved from cache so it's not an issue.
+        _mediaThemeStateStore.GetMediaThemeStateAsync().GetAwaiter().GetResult()?.BaseThemeId;
 }


### PR DESCRIPTION
Currently MediaTheme's ExtensionManagerDecorator decorates the registered IExtensionManager type to include it's dynamically selected base theme as a MediaTheme dependency.

This works everywhere in OrchardCore (OC) where IExtensionManager is used with depencency injection (DI).

But, the default implementation ExtensionManager internally calls GetFeatureDependencies() without DI bypassing MediaTheme's decoration for including the base theme as a dependency.

Fixes repo issue #30, JIRA issue [OSOE-529](https://lombiq.atlassian.net/browse/OSOE-529)

I spent time looking deep into Orchard Core to see if I could find a more elegant solution but I have a bit more to learn before I do that. Specifically, I think the ThemeBuilderEvents and ThemeExtensionDependencyStrategy extend ExtensionManager through the FeaturesProvider type. I briefly tried to go down that path but gave up once I learned how explicitly setting the BaseTheme in the Manifest.cs file worked.

To test,
1. Create a new site with TheBlogRecipe
2. Enable the MediaTheme feature
3. Enable Lucene Query Search feature
4. Set current theme to Media Theme
5. Go to admin UI Settings, Media Theme, select base theme to be The Blog Theme
6. Navigate to site's /search URL and observe the header zone is rendered from the Search shape in TheBlogTheme


OSOE-529

[OSOE-529]: https://lombiq.atlassian.net/browse/OSOE-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ